### PR TITLE
feat(colors): add color resource

### DIFF
--- a/DeliBuddy/app/src/main/res/layout/activity_permission_description.xml
+++ b/DeliBuddy/app/src/main/res/layout/activity_permission_description.xml
@@ -41,7 +41,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="36dp"
         android:layout_marginTop="20dp"
-        android:outlineSpotShadowColor="@color/cv_shadow_grey"
+        android:outlineSpotShadowColor="@color/shadow_grey"
         app:cardCornerRadius="10dp"
         app:cardElevation="20dp"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/DeliBuddy/app/src/main/res/values/colors.xml
+++ b/DeliBuddy/app/src/main/res/values/colors.xml
@@ -11,16 +11,31 @@
     <color name="main_orange">#F15641</color>
     <color name="sub_yellow">#F5CD3D</color>
     <color name="sub_purple">#7F1DC1</color>
-    <color name="light_grey_background">#E5E5E5</color>
-    <color name="main_background">#FDFDFD</color>
+    <color name="sub_grey">#B8B8B8</color>
 
-    <color name="divider_grey">#E5E5E5</color>
+    <color name="main_background">#FDFDFD</color>
 
     <color name="splash_background_start">#F57C6C</color>
     <color name="splash_background_end">#E73B23</color>
-    
+
+    <color name="divider_grey">#EDEDED</color>
+    <color name="block_space_grey">#F0F0F0</color>
+    <color name="shadow_grey">#0F202020</color>
+
+    <color name="chicken_background">#FFEEDE</color>
+    <color name="chinese_background"></color>
+    <color name="pizza_background">#FFE3D8</color>
+    <color name="burger_background">#FAF3CE</color>
+    <color name="korean_background">#FFEEDE</color>
+    <color name="snack_background">#F5DADC</color>
+    <color name="desert_background">#EDE4DA</color>
+    <color name="bread_background">#FCDDBA</color>
+    <color name="japanese_background">#DBDCF3</color>
+    <color name="seafood_background">#EDEDED</color>
+    <color name="western_background">#D1F4CA</color>
+
+    <color name="text_orange">#F15641</color>
+    <color name="text_light_grey">#D1D1D1</color>
     <color name="text_grey">#686868</color>
     <color name="text_black">#000000</color>
-
-    <color name="cv_shadow_grey">#0F202020</color>
 </resources>


### PR DESCRIPTION
색상 리소스 추가
- 피그마에 나와 있는 네이밍은 조금 헷갈리는 부분도 있어서 동일한 색이라도 쓰임에 따라서 이름을 변경하여 설정해 보았습니다!
- 구분선은 divider_grey
- 입력칸이나, 파티 완료 후 비활성화되는 칸 색상은 block_space_grey
- <주문 중>, <미주문> 태그의 노란색, 보라색은 서브 컬러로 해 놓으셨길래 같은 용도의 <주문완료> 회색 색상은 sub_grey로 해 두었습니다
- 중식 배경색의 경우 디자이너 분께서 아직 알려주시지 않아서 비어 있습니다..
- 더 좋은 이름이 있으시다면 제안해 주세요!!