### PR TITLE
Feat(partyInfo): 파티상세화면 마무리 작업 (2/2)

### DIFF
--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/CommentAdapter.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/CommentAdapter.kt
@@ -55,10 +55,10 @@ class CommentAdapter(
 
     override fun getItemViewType(position: Int): Int {
         return when(currentList[position]){
-            is Comment -> PARENT
+            is Comment      -> PARENT
             is ChildComment -> CHILD
             is EmptyComment -> EMPTY
-            else -> throw IllegalArgumentException("올바르지 않은 CommentType입니다.")
+            else            -> throw IllegalArgumentException("올바르지 않은 CommentType입니다.")
         }
     }
 

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/CommentViewHolder.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/CommentViewHolder.kt
@@ -24,8 +24,8 @@ class ParentCommentViewHolder(
 
     fun onBind(comment: Comment, listener: CommentEventListener, isOwner: Boolean) = with(binding) {
         tvWriterNickname.text = comment.writer?.nickName
-        tvBody.text = comment.body
-        tvTimeAgo.text = comment.createdAt
+        tvBody.text           = comment.body
+        tvTimeAgo.text        = comment.createdAt
 
         Glide.with(itemView)
             .load(comment.writer?.profileImage)
@@ -66,8 +66,8 @@ class ChildCommentViewHolder(
 
     fun onBind(comment: ChildComment, listener: CommentEventListener, isOwner: Boolean) = with(binding) {
         tvWriterNickname.text = comment.writer?.nickName
-        tvBody.text = comment.body
-        tvTimeAgo.text = comment.createdAt
+        tvBody.text           = comment.body
+        tvTimeAgo.text        = comment.createdAt
         ivOptions.setOnClickListener {
             listener.invoke(CommentEvent.OnRemoveCommentClicked(comment))
         }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/UserAdapter.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/UserAdapter.kt
@@ -22,6 +22,8 @@ internal class UserAdapter : ListAdapter<PartyInformation.User, UserViewHolder>(
             notifyDataSetChanged()
         }
 
+    private var listener: ((PartyInformation.User) -> Unit)? = null
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemUserBinding.inflate(layoutInflater, parent, false)
@@ -30,8 +32,11 @@ internal class UserAdapter : ListAdapter<PartyInformation.User, UserViewHolder>(
     }
 
     override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
-        val isFirstUser = position == 0
-        holder.onBind(getItem(position), isOwner, leader)
+        holder.onBind(getItem(position), isOwner, leader, listener)
+    }
+
+    fun setBanButtonListener(listener: (PartyInformation.User) -> Unit) {
+        this.listener = listener
     }
 
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/UserViewHolder.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/adapter/comment/UserViewHolder.kt
@@ -9,19 +9,27 @@ import yapp.android1.delibuddy.util.extensions.show
 
 
 class UserViewHolder(private val binding: ItemUserBinding) : RecyclerView.ViewHolder(binding.root) {
-    fun onBind(user: PartyInformation.User, isOwner: Boolean, leader: PartyInformation.Leader) = with(binding) {
+    fun onBind(
+        user: PartyInformation.User,
+        isOwner: Boolean,
+        leader: PartyInformation.Leader,
+        listener: ((PartyInformation.User) -> Unit)?
+    ) = with(binding) {
         binding.tvUsername.text = user.nickName
 
         if(isOwner) {
-            ivIconOwner.show()
-            btnKickOut.show()
+            btnBan.show()
+            btnBan.setOnClickListener {
+                listener?.invoke(user)
+            }
 
             if(leader.id == user.id) {
-                btnKickOut.hide()
+                ivIconOwner.show()
+                btnBan.hide()
             }
         } else {
             ivIconOwner.hide()
-            btnKickOut.hide()
+            btnBan.hide()
         }
 
         Glide.with(itemView)

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/di/DomainModule.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/di/DomainModule.kt
@@ -85,4 +85,8 @@ object DomainModule {
         return EditPartyUseCase(partyRepository)
     }
 
+    @Provides
+    fun provideBanFromPartyUseCase(partyRepository: PartyRepository): BanFromPartyUseCase {
+        return BanFromPartyUseCase(partyRepository)
+    }
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/model/Party.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/model/Party.kt
@@ -21,36 +21,36 @@ data class Party(
 ) : Serializable {
     companion object {
         val EMPTY = Party(
-            allStatuses = emptyList(),
-            body = "",
-            category = Category.EMPTY,
-            coordinate = "",
+            allStatuses      = emptyList(),
+            body             = "",
+            category         = Category.EMPTY,
+            coordinate       = "",
             currentUserCount = -1,
-            id = -1,
-            openKakaoUrl = "",
-            orderTime = "",
-            placeName = "",
-            placeNameDetail = "",
-            status = "",
-            targetUserCount = -1,
-            title = ""
+            id               = -1,
+            openKakaoUrl     = "",
+            orderTime        = "",
+            placeName        = "",
+            placeNameDetail  = "",
+            status           = "",
+            targetUserCount  = -1,
+            title            = ""
         )
 
         fun toParty(partyEntity: PartyEntity): Party {
             return Party(
-                allStatuses = partyEntity.allStatuses,
-                body = partyEntity.body,
-                category = Category.mapToCategory(partyEntity.category),
-                coordinate = partyEntity.coordinate,
+                allStatuses      = partyEntity.allStatuses,
+                body             = partyEntity.body,
+                category         = Category.mapToCategory(partyEntity.category),
+                coordinate       = partyEntity.coordinate,
                 currentUserCount = partyEntity.currentUserCount,
-                id = partyEntity.id,
-                openKakaoUrl = partyEntity.openKakaoUrl,
-                orderTime = parseDate(partyEntity.orderTime),
-                placeName = partyEntity.placeName,
-                placeNameDetail = partyEntity.placeNameDetail,
-                status = partyEntity.status,
-                targetUserCount = partyEntity.targetUserCount,
-                title = partyEntity.title
+                id               = partyEntity.id,
+                openKakaoUrl     = partyEntity.openKakaoUrl,
+                orderTime        = parseDate(partyEntity.orderTime),
+                placeName        = partyEntity.placeName,
+                placeNameDetail  = partyEntity.placeNameDetail,
+                status           = partyEntity.status,
+                targetUserCount  = partyEntity.targetUserCount,
+                title            = partyEntity.title
             )
         }
     }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/model/PartyInformation.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/model/PartyInformation.kt
@@ -33,17 +33,17 @@ data class PartyInformation(
     ) : Serializable {
         companion object {
             val EMPTY = Leader(
-                id = -1,
-                nickName = "",
-                partiesCnt = 0,
+                id           = -1,
+                nickName     = "",
+                partiesCnt   = 0,
                 profileImage = ""
             )
 
             fun toLeader(entity: PartyInformationEntity.LeaderEntity): Leader {
                 return Leader(
-                    id = entity.id,
-                    nickName = entity.nickName,
-                    partiesCnt = entity.partiesCnt,
+                    id           = entity.id,
+                    nickName     = entity.nickName,
+                    partiesCnt   = entity.partiesCnt,
                     profileImage = entity.profileImage
                 )
             }
@@ -59,9 +59,9 @@ data class PartyInformation(
         companion object {
             fun toUser(entity: PartyInformationEntity.UserEntity): User {
                 return User(
-                    id = entity.id,
-                    nickName = entity.nickName,
-                    partiesCnt = entity.partiesCnt,
+                    id           = entity.id,
+                    nickName     = entity.nickName,
+                    partiesCnt   = entity.partiesCnt,
                     profileImage = entity.profileImage
                 )
             }
@@ -71,42 +71,42 @@ data class PartyInformation(
 
     companion object {
         val EMPTY = PartyInformation(
-            allStatuses = emptyList(),
-            body = "",
-            category = Category.EMPTY,
-            coordinate = "",
+            allStatuses      = emptyList(),
+            body             = "",
+            category         = Category.EMPTY,
+            coordinate       = "",
             currentUserCount = -1,
-            id = -1,
-            openKakaoUrl = "",
-            orderTime = "",
-            placeName = "",
-            placeNameDetail = "",
-            status = PartyStatus.RECRUIT,
-            targetUserCount = -1,
-            title = "",
-            isIn = false,
-            leader = Leader.EMPTY,
-            users = emptyList()
+            id               = -1,
+            openKakaoUrl     = "",
+            orderTime        = "",
+            placeName        = "",
+            placeNameDetail  = "",
+            status           = PartyStatus.RECRUIT,
+            targetUserCount  = -1,
+            title            = "",
+            isIn             = false,
+            leader           = Leader.EMPTY,
+            users            = emptyList()
         )
 
         fun toPartyInformation(partyEntity: PartyInformationEntity): PartyInformation {
             return PartyInformation(
-                allStatuses = partyEntity.allStatuses,
-                body = partyEntity.body,
-                category = Category.mapToCategory(partyEntity.category),
-                coordinate = partyEntity.coordinate,
+                allStatuses      = partyEntity.allStatuses,
+                body             = partyEntity.body,
+                category         = Category.mapToCategory(partyEntity.category),
+                coordinate       = partyEntity.coordinate,
                 currentUserCount = partyEntity.currentUserCount,
-                id = partyEntity.id,
-                openKakaoUrl = partyEntity.openKakaoUrl,
-                orderTime = parseDate(partyEntity.orderTime),
-                placeName = partyEntity.placeName,
-                placeNameDetail = partyEntity.placeNameDetail,
-                status = PartyStatus.of(partyEntity.status),
-                targetUserCount = partyEntity.targetUserCount,
-                title = partyEntity.title,
-                isIn = partyEntity.isIn,
-                leader = Leader.toLeader(partyEntity.leader),
-                users = partyEntity.users.map { User.toUser(it) }
+                id               = partyEntity.id,
+                openKakaoUrl     = partyEntity.openKakaoUrl,
+                orderTime        = parseDate(partyEntity.orderTime),
+                placeName        = partyEntity.placeName,
+                placeNameDetail  = partyEntity.placeNameDetail,
+                status           = PartyStatus.of(partyEntity.status),
+                targetUserCount  = partyEntity.targetUserCount,
+                title            = partyEntity.title,
+                isIn             = partyEntity.isIn,
+                leader           = Leader.toLeader(partyEntity.leader),
+                users            = partyEntity.users.map { User.toUser(it) }
             )
         }
     }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
@@ -100,12 +100,7 @@ class PartyInformationActivity : AppCompatActivity() {
         when (event) {
             is PartyInformationEvent.OnPartyJoinSuccess       -> { openOpenKakaoTalk(event.openKakaoTalkUrl) }
             is PartyInformationEvent.OnPartyJoinFailed        -> { showToast("파티 인원이 다 찼습니다") }
-            is PartyInformationEvent.OnCreateCommentSuccess   -> {
-                binding.etInputComment.setText("")
-                showToast("댓글이 정상적으로 등록되었습니다")
-                binding.etInputComment.hideKeyboard()
-                hideTargetComment()
-            }
+            is PartyInformationEvent.OnCreateCommentSuccess   -> { handleWriteCommentSuccess() }
             is PartyInformationEvent.OnCreateCommentFailed    -> { showToast("댓글 작성에 실패했습니다 다시 시도해 주세요") }
             is PartyInformationEvent.ShowTargetParentComment  -> { showTargetComment(event.parentComment) }
             is PartyInformationEvent.HideTargetParentComment  -> { hideTargetComment() }
@@ -115,6 +110,13 @@ class PartyInformationActivity : AppCompatActivity() {
             is PartyInformationEvent.CommentDeleteFailed      -> { showToast("댓글 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요") }
             else -> Unit
         }
+    }
+
+    private fun handleWriteCommentSuccess() = with(binding) {
+        etInputComment.setText("")
+        showToast("댓글이 정상적으로 등록되었습니다")
+        etInputComment.hideKeyboard()
+        hideTargetComment()
     }
 
     private fun showTargetComment(parentComment: Comment) = with(binding) {

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
@@ -3,6 +3,7 @@ package yapp.android1.delibuddy.ui.partyInformation
 import android.animation.Animator
 import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.Typeface
@@ -54,25 +55,23 @@ class PartyInformationActivity : AppCompatActivity() {
 
     private val sharedPreferencesManager by lazy { SharedPreferencesManager(this) }
 
-    private val partyEditContract =
-        registerForActivityResult(PartyInformationContract()) { resultAction ->
-            viewModel.occurEvent(resultAction)
-        }
+    private val partyEditContract = registerForActivityResult(PartyInformationContract()) { resultAction ->
+        viewModel.occurEvent(resultAction)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityPartyInformationBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        initializePos()
         initializeView()
         initializeViewPager()
         initializeCollapsing()
-        receiverIntent()
+        receiveIntent()
         collectData()
     }
 
-    private fun receiverIntent() {
+    private fun receiveIntent() {
         val intentData = intent.getSerializableExtra("party") as Party
         viewModel.occurEvent(OnIntent(intentData, sharedPreferencesManager.getUserId()))
     }
@@ -99,62 +98,28 @@ class PartyInformationActivity : AppCompatActivity() {
 
     private fun handleEvent(event: PartyInformationEvent) {
         when (event) {
-            is PartyInformationEvent.OnPartyJoinSuccess -> {
-                openOpenKakaoTalk(event.openKakaoTalkUrl)
-            }
-
-            is PartyInformationEvent.OnPartyJoinFailed -> {
-                Toast.makeText(this, "파티 인원이 다 찼습니다.", Toast.LENGTH_SHORT).show()
-            }
-
-            is PartyInformationEvent.OnCreateCommentSuccess -> {
+            is PartyInformationEvent.OnPartyJoinSuccess       -> { openOpenKakaoTalk(event.openKakaoTalkUrl) }
+            is PartyInformationEvent.OnPartyJoinFailed        -> { showToast("파티 인원이 다 찼습니다") }
+            is PartyInformationEvent.OnCreateCommentSuccess   -> {
                 binding.etInputComment.setText("")
-                Toast.makeText(this, "댓글이 정상적으로 등록되었습니다", Toast.LENGTH_SHORT).show()
-
+                showToast("댓글이 정상적으로 등록되었습니다")
                 binding.etInputComment.hideKeyboard()
                 hideTargetComment()
             }
-
-            is PartyInformationEvent.OnCreateCommentFailed -> {
-                Toast.makeText(this, "댓글 작성에 실패했습니다 다시 시도해 주세요", Toast.LENGTH_SHORT).show()
-            }
-
-            is PartyInformationEvent.ShowTargetParentComment -> {
-                showTargetComment(event.parentComment)
-            }
-
-            is PartyInformationEvent.HideTargetParentComment -> {
-                hideTargetComment()
-            }
-
-            is PartyInformationEvent.PartyDeleteSuccess -> {
-                finish()
-            }
-
-            is PartyInformationEvent.PartyDeleteFailed -> {
-                Toast.makeText(this, "파티 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.", Toast.LENGTH_SHORT).show()
-            }
-
-            is PartyInformationEvent.CommentDeleteSuccess -> {
-                Toast.makeText(this, "댓글이 성공적으로 삭제됐습니다.", Toast.LENGTH_SHORT).show()
-            }
-
-            is PartyInformationEvent.CommentDeleteFailed -> {
-                Toast.makeText(this, "댓글 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.", Toast.LENGTH_SHORT).show()
-            }
-
+            is PartyInformationEvent.OnCreateCommentFailed    -> { showToast("댓글 작성에 실패했습니다 다시 시도해 주세요") }
+            is PartyInformationEvent.ShowTargetParentComment  -> { showTargetComment(event.parentComment) }
+            is PartyInformationEvent.HideTargetParentComment  -> { hideTargetComment() }
+            is PartyInformationEvent.PartyDeleteSuccess       -> { finish() }
+            is PartyInformationEvent.PartyDeleteFailed        -> { showToast("파티 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요") }
+            is PartyInformationEvent.CommentDeleteSuccess     -> { showToast("댓글이 성공적으로 삭제됐습니다") }
+            is PartyInformationEvent.CommentDeleteFailed      -> { showToast("댓글 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요") }
             else -> Unit
         }
     }
 
-    private fun initializePos() {
-        binding.root.translationY = binding.clTargetCommentContainer.measuredHeight.toFloat()
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
     private fun showTargetComment(parentComment: Comment) = with(binding) {
         tvParentCommentWriter.text = parentComment.writer?.nickName + " 님에게 답장"
-        tvParentCommentBody.text = parentComment.body
+        tvParentCommentBody.text   = parentComment.body
         showTargetCommentAnimation()
 
         etInputComment.showKeyboard()
@@ -162,7 +127,7 @@ class PartyInformationActivity : AppCompatActivity() {
 
     private fun hideTargetComment() = with(binding) {
         tvParentCommentWriter.text = ""
-        tvParentCommentBody.text = ""
+        tvParentCommentBody.text   = ""
         hideTargetCommentAnimation()
     }
 
@@ -217,14 +182,14 @@ class PartyInformationActivity : AppCompatActivity() {
     }
 
     private fun setDisableJoinButton() = with(binding) {
-        binding.btnJoinParty.text = "파티 참가"
+        btnJoinParty.text = "파티 참가"
     }
 
     private fun settingPartyInformationViews(party: PartyInformation) = with(binding) {
         // [Header]
         tvPartyLocation.text = "${party.placeName} \n${party.placeNameDetail}"
-        tvPartyTitle.text = party.title
-        tvPartyContent.text = party.body
+        tvPartyTitle.text    = party.title
+        tvPartyContent.text  = party.body
 
         tvOrderTime.text = party.orderTime + " 주문 예정"
         val span = tvOrderTime.text as Spannable
@@ -258,17 +223,17 @@ class PartyInformationActivity : AppCompatActivity() {
             }
         }
 
-        tvStatus.text = party.status.value
+        tvStatus.text       = party.status.value
         tvStatusChange.text = party.status.value
 
         // [ Toolbar ]
-        toolbarContainer.tvTitle.text = party.title
+        toolbarContainer.tvTitle.text    = party.title
         toolbarContainer.tvLocation.text = "${party.placeName} ${party.placeNameDetail}"
 
         // [Party Owner]
         tvPartyOwnerName.text = party.leader.nickName
 
-        tvPartyOwnerPartiesCount.text = "버디와 함께한 식사 ${party.leader.partiesCnt}번"
+        tvPartyOwnerPartiesCount.text    = "버디와 함께한 식사 ${party.leader.partiesCnt}번"
         val tvPartyOwnerPartiesCountSpan = tvPartyOwnerPartiesCount.text as Spannable
         tvPartyOwnerPartiesCountSpan.setSpan(
             StyleSpan(Typeface.BOLD),
@@ -307,11 +272,10 @@ class PartyInformationActivity : AppCompatActivity() {
         }
 
         btnCreateComment.setOnClickListener {
-            if (etInputComment.text.toString() != "") {
+            if (etInputComment.text.toString().trim() != "") {
                 viewModel.occurEvent(PartyInformationAction.WriteComment(etInputComment.text.toString()))
             } else {
-                Toast.makeText(this@PartyInformationActivity, "댓글 내용을 입력해주세요", Toast.LENGTH_SHORT)
-                    .show()
+                showToast("댓글 내용을 입력해주세요")
             }
         }
 
@@ -320,7 +284,7 @@ class PartyInformationActivity : AppCompatActivity() {
         }
 
         toolbarContainer.btnMoreOptions.setOnClickListener { optionsButton ->
-            val editButton = optionsMenuBalloon.getContentView().findViewById<ConstraintLayout>(R.id.btn_edit)
+            val editButton   = optionsMenuBalloon.getContentView().findViewById<ConstraintLayout>(R.id.btn_edit)
             val removeButton = optionsMenuBalloon.getContentView().findViewById<ConstraintLayout>(R.id.btn_remove)
 
             editButton.setOnClickListener {
@@ -398,6 +362,10 @@ class PartyInformationActivity : AppCompatActivity() {
 
     private fun openOpenKakaoTalk(url: String) {
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    }
+
+    private fun Context.showToast(body: String, duration: Int = Toast.LENGTH_SHORT) {
+        Toast.makeText(this, body, duration).show()
     }
 
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationActivity.kt
@@ -4,6 +4,7 @@ import android.animation.Animator
 import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.Typeface
@@ -25,6 +26,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.dialog.MaterialDialogs
 import com.google.android.material.tabs.TabLayoutMediator
 import com.skydoves.balloon.*
 import dagger.hilt.android.AndroidEntryPoint
@@ -296,7 +299,12 @@ class PartyInformationActivity : AppCompatActivity() {
 
             removeButton.setOnClickListener {
                 optionsMenuBalloon.dismiss()
-                viewModel.occurEvent(PartyInformationAction.OnDeletePartyMenuClicked)
+                showCustomDialog(
+                    title          = "경고",
+                    message        = "정말 해당 파티를 삭제하시겠습니까?",
+                    positiveMethod = { viewModel.occurEvent(PartyInformationAction.OnDeletePartyMenuClicked) },
+                    negativeMethod = null
+                )
             }
 
             optionsMenuBalloon.showAlignBottom(optionsButton)
@@ -364,10 +372,6 @@ class PartyInformationActivity : AppCompatActivity() {
 
     private fun openOpenKakaoTalk(url: String) {
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-    }
-
-    private fun Context.showToast(body: String, duration: Int = Toast.LENGTH_SHORT) {
-        Toast.makeText(this, body, duration).show()
     }
 
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationContract.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationContract.kt
@@ -20,10 +20,8 @@ internal class PartyInformationContract : ActivityResultContract<PartyInformatio
 
     override fun parseResult(resultCode: Int, intent: Intent?): PartyInformationViewModel.PartyInformationAction {
         return when(resultCode) {
-            Activity.RESULT_OK -> {
-                //val editedPartyInformation = intent?.getSerializableExtra(EDIT_PARTYINFO_RESULT) as PartyInformation
-                PartyInformationViewModel.PartyInformationAction.PartyEditSuccess
-            }
+            Activity.RESULT_OK -> PartyInformationViewModel.PartyInformationAction.PartyEditSuccess
+
             else -> PartyInformationViewModel.PartyInformationAction.PartyEditFailed
         }
     }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
@@ -1,10 +1,8 @@
 package yapp.android1.delibuddy.ui.partyInformation
 
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import yapp.android1.delibuddy.base.BaseViewModel
 import yapp.android1.delibuddy.base.RetryAction
 import yapp.android1.delibuddy.model.*
@@ -22,13 +20,13 @@ import javax.inject.Inject
 @HiltViewModel
 class PartyInformationViewModel @Inject constructor(
     private val fetchPartyInformationUseCase: FetchPartyInformationUseCase,
-    private val fetchPartyCommentsUseCase: FetchPartyCommentsUseCase,
-    private val jointPartyUseCase: JoinPartyUseCase,
-    private val changeStatusUseCase: ChangeStatusUseCase,
-    private val createCommentUseCase: CreateCommentUseCase,
-    private val deletePartyUseCase: DeletePartyUseCase,
-    private val deleteCommentUseCase: DeleteCommentUseCase,
-    private val banFromPartyUseCase: BanFromPartyUseCase
+    private val fetchPartyCommentsUseCase   : FetchPartyCommentsUseCase,
+    private val jointPartyUseCase           : JoinPartyUseCase,
+    private val changeStatusUseCase         : ChangeStatusUseCase,
+    private val createCommentUseCase        : CreateCommentUseCase,
+    private val deletePartyUseCase          : DeletePartyUseCase,
+    private val deleteCommentUseCase        : DeleteCommentUseCase,
+    private val banFromPartyUseCase         : BanFromPartyUseCase
 ) : BaseViewModel<PartyInformationAction>() {
 
     private val _event = MutableEventFlow<PartyInformationEvent>()
@@ -49,32 +47,40 @@ class PartyInformationViewModel @Inject constructor(
     private var currentUserId = -1
 
     sealed class PartyInformationAction : Event {
+        // [Party]
         class OnIntent(val data: Party, val currentUserId: Int) : PartyInformationAction()
         class OnStatusChanged(val status: PartyStatus) : PartyInformationAction()
         object OnJointPartyClicked : PartyInformationAction()
-        class DeleteComment(val commentId: Int) : PartyInformationAction()
-        class WriteComment(val body: String) : PartyInformationAction()
-        class OnCommentWriteTextViewClicked(val parentComment: Comment) : PartyInformationAction()
-        object DeleteTargetComment : PartyInformationAction()
-        object OnTouchBackground : PartyInformationAction()
         object OnDeletePartyMenuClicked : PartyInformationAction()
         object PartyEditSuccess : PartyInformationAction()
         object PartyEditFailed : PartyInformationAction()
 
+        // [Comment]
+        class DeleteComment(val commentId: Int) : PartyInformationAction()
+        class WriteComment(val body: String) : PartyInformationAction()
+        class OnCommentWriteTextViewClicked(val parentComment: Comment) : PartyInformationAction()
+        object DeleteTargetComment : PartyInformationAction()
+
+        // [User]
         class BanUserFromParty(val targetUser: PartyInformation.User) : PartyInformationAction()
     }
 
     sealed class PartyInformationEvent : Event {
+        // [Party]
         class OnPartyJoinSuccess(val openKakaoTalkUrl: String) : PartyInformationEvent()
         object OnPartyJoinFailed : PartyInformationEvent()
+        object PartyDeleteSuccess : PartyInformationEvent()
+        object PartyDeleteFailed : PartyInformationEvent()
+
+        // [Comment]
         object OnCreateCommentSuccess : PartyInformationEvent()
         object OnCreateCommentFailed : PartyInformationEvent()
         class ShowTargetParentComment(val parentComment: Comment) : PartyInformationEvent()
         object HideTargetParentComment : PartyInformationEvent()
-        object PartyDeleteSuccess : PartyInformationEvent()
-        object PartyDeleteFailed : PartyInformationEvent()
         object CommentDeleteSuccess : PartyInformationEvent()
         object CommentDeleteFailed : PartyInformationEvent()
+
+        // [User]
         object UserBanSuccess : PartyInformationEvent()
         object UserBanFailed : PartyInformationEvent()
     }
@@ -109,7 +115,7 @@ class PartyInformationViewModel @Inject constructor(
             is PartyInformationAction.WriteComment -> {
                 if (isWritingChildComment()) {
                     createComment(
-                        body = action.body,
+                        body     = action.body,
                         parentId = (_targetParentComment.value as Comment).id
                     )
                 } else {
@@ -130,11 +136,6 @@ class PartyInformationViewModel @Inject constructor(
                 _event.emit(PartyInformationEvent.ShowTargetParentComment(action.parentComment))
             }
 
-            is PartyInformationAction.OnTouchBackground -> {
-                _targetParentComment.value = null
-                _event.emit(PartyInformationEvent.HideTargetParentComment)
-            }
-
             is PartyInformationAction.OnDeletePartyMenuClicked -> {
                 deleteParty()
             }
@@ -152,22 +153,22 @@ class PartyInformationViewModel @Inject constructor(
 
     private fun setPartyWithoutLeader(party: Party) {
         _party.value = PartyInformation(
-            id = party.id,
-            allStatuses = party.allStatuses,
-            body = party.body,
-            category = party.category,
-            coordinate = party.coordinate,
+            id               = party.id,
+            allStatuses      = party.allStatuses,
+            body             = party.body,
+            category         = party.category,
+            coordinate       = party.coordinate,
             currentUserCount = party.currentUserCount,
-            openKakaoUrl = party.openKakaoUrl,
-            orderTime = party.orderTime,
-            placeName = party.placeName,
-            placeNameDetail = party.placeNameDetail,
-            status = PartyStatus.of(party.status),
-            targetUserCount = party.targetUserCount,
-            title = party.title,
-            isIn = false,
-            leader = PartyInformation.Leader.EMPTY,
-            users = emptyList()
+            openKakaoUrl     = party.openKakaoUrl,
+            orderTime        = party.orderTime,
+            placeName        = party.placeName,
+            placeNameDetail  = party.placeNameDetail,
+            status           = PartyStatus.of(party.status),
+            targetUserCount  = party.targetUserCount,
+            title            = party.title,
+            isIn             = false,
+            leader           = PartyInformation.Leader.EMPTY,
+            users            = emptyList()
         )
     }
 
@@ -175,14 +176,12 @@ class PartyInformationViewModel @Inject constructor(
 
     private suspend fun createComment(body: String, parentId: Int? = null) {
         val params = CommentCreationRequestEntity(
-            body = body,
+            body     = body,
             parentId = parentId,
-            partyId = _party.value.id
+            partyId  = _party.value.id
         )
-        val result = createCommentUseCase.invoke(
-            CreateCommentUseCase.Params(requestEntity = params)
-        )
-        when (result) {
+
+        when (val result = createCommentUseCase.invoke(CreateCommentUseCase.Params(requestEntity = params))) {
             is NetworkResult.Success -> {
                 fetchPartyComments(_party.value.id)
                 _targetParentComment.value = null
@@ -214,7 +213,7 @@ class PartyInformationViewModel @Inject constructor(
     private suspend fun changePartyStatus(partyId: Int, changedStatus: String) {
         val result = changeStatusUseCase.invoke(
             params = ChangeStatusUseCase.Params(
-                partyId = partyId,
+                partyId       = partyId,
                 changedStatus = changedStatus
             )
         )
@@ -300,22 +299,22 @@ class PartyInformationViewModel @Inject constructor(
 
     private suspend fun banFromParty(user: PartyInformation.User) {
         val params = BanFromPartyUseCase.Params(
-            partyId = _party.value.id,
+            partyId       = _party.value.id,
             requestEntity = PartyBanRequestEntity(targetId = user.id)
         )
 
-        when(val result = banFromPartyUseCase(params)) {
+        when (val result = banFromPartyUseCase(params)) {
             is NetworkResult.Success -> {
                 val isSuccess = result.data
 
-                if(isSuccess) {
+                if (isSuccess) {
                     fetchPartyInformation(_party.value.id)
                     _event.emit(PartyInformationEvent.UserBanSuccess)
                 } else {
                     _event.emit(PartyInformationEvent.UserBanFailed)
                 }
             }
-            is NetworkResult.Error ->{
+            is NetworkResult.Error -> {
                 _event.emit(PartyInformationEvent.UserBanFailed)
             }
         }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
@@ -60,7 +60,7 @@ class PartyInformationViewModel @Inject constructor(
     }
 
     sealed class PartyInformationEvent : Event {
-        object OnPartyJoinSuccess : PartyInformationEvent()
+        class OnPartyJoinSuccess(val openKakaoTalkUrl: String) : PartyInformationEvent()
         object OnPartyJoinFailed : PartyInformationEvent()
         object OnCreateCommentSuccess : PartyInformationEvent()
         object OnCreateCommentFailed : PartyInformationEvent()
@@ -93,6 +93,9 @@ class PartyInformationViewModel @Inject constructor(
             is PartyInformationAction.OnJointPartyClicked -> {
                 if (_party.value.isIn == false) {
                     joinParty()
+                    _event.emit(PartyInformationEvent.OnPartyJoinSuccess(_party.value.openKakaoUrl!!))
+                } else {
+                    _event.emit(PartyInformationEvent.OnPartyJoinSuccess(_party.value.openKakaoUrl!!))
                 }
             }
 
@@ -222,7 +225,7 @@ class PartyInformationViewModel @Inject constructor(
             is NetworkResult.Success -> {
                 if (result.data == true) {
                     fetchPartyInformation(_party.value.id)
-                    _event.emit(PartyInformationEvent.OnPartyJoinSuccess)
+                    _event.emit(PartyInformationEvent.OnPartyJoinSuccess(_party.value.openKakaoUrl!!))
                 } else {
                     _event.emit(PartyInformationEvent.OnPartyJoinFailed)
                 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/PartyInformationViewModel.kt
@@ -53,6 +53,7 @@ class PartyInformationViewModel @Inject constructor(
         class DeleteComment(val commentId: Int) : PartyInformationAction()
         class WriteComment(val body: String) : PartyInformationAction()
         class OnCommentWriteTextViewClicked(val parentComment: Comment) : PartyInformationAction()
+        object DeleteTargetComment : PartyInformationAction()
         object OnTouchBackground : PartyInformationAction()
         object OnDeletePartyMenuClicked : PartyInformationAction()
         object PartyEditSuccess : PartyInformationAction()
@@ -112,6 +113,10 @@ class PartyInformationViewModel @Inject constructor(
 
             is PartyInformationAction.DeleteComment -> {
                 deleteComment(action.commentId)
+            }
+
+            is PartyInformationAction.DeleteTargetComment -> {
+                _targetParentComment.value = null
             }
 
             is PartyInformationAction.OnCommentWriteTextViewClicked -> {

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/CommentTabFragment.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/CommentTabFragment.kt
@@ -25,7 +25,7 @@ import yapp.android1.delibuddy.util.extensions.repeatOnStarted
 @AndroidEntryPoint
 class CommentTabFragment : BaseFragment<FragmentCommentTabBinding>(FragmentCommentTabBinding::inflate) {
 
-    private val viewModel = activityViewModels<PartyInformationViewModel>()
+    private val viewModel by activityViewModels<PartyInformationViewModel>()
 
     private lateinit var commentAdapter: CommentAdapter
 
@@ -52,27 +52,26 @@ class CommentTabFragment : BaseFragment<FragmentCommentTabBinding>(FragmentComme
     }
 
     private fun collectComments() {
-
         repeatOnStarted {
-            viewModel.value.isOwner.collect { isOwner->
+            viewModel.isOwner.collect { isOwner->
                 commentAdapter.isOwner = isOwner
             }
         }
 
         repeatOnStarted {
-            viewModel.value.comments.collect { comments ->
+            viewModel.comments.collect { comments ->
                 commentAdapter.submitList(comments.value)
             }
         }
 
         repeatOnStarted {
-            viewModel.value.showToast.collect {
+            viewModel.showToast.collect {
                 Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
             }
         }
 
         repeatOnStarted {
-            viewModel.value.event.collect { event ->
+            viewModel.event.collect { event ->
                 handleEvent(event)
             }
         }
@@ -86,8 +85,9 @@ class CommentTabFragment : BaseFragment<FragmentCommentTabBinding>(FragmentComme
 
     private fun handleCommentEvent(event: CommentEvent) {
         when(event) {
-            is CommentEvent.OnWriteCommentClicked -> viewModel.value.occurEvent(OnCommentWriteTextViewClicked(event.comment as Comment))
-            is CommentEvent.OnRemoveCommentClicked -> viewModel.value.occurEvent(DeleteComment(event.comment.id))
+            is CommentEvent.OnWriteCommentClicked  -> viewModel.occurEvent(OnCommentWriteTextViewClicked(event.comment as Comment))
+            is CommentEvent.OnRemoveCommentClicked -> viewModel.occurEvent(DeleteComment(event.comment.id))
         }
     }
+
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/UserListTabFragment.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/UserListTabFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -15,6 +16,7 @@ import yapp.android1.delibuddy.adapter.comment.UserAdapter
 import yapp.android1.delibuddy.base.BaseFragment
 import yapp.android1.delibuddy.databinding.FragmentUserListTabBinding
 import yapp.android1.delibuddy.ui.partyInformation.PartyInformationViewModel
+import yapp.android1.delibuddy.ui.partyInformation.PartyInformationViewModel.PartyInformationAction.*
 import yapp.android1.delibuddy.util.extensions.repeatOnStarted
 
 @AndroidEntryPoint
@@ -27,7 +29,7 @@ class UserListTabFragment : BaseFragment<FragmentUserListTabBinding>(FragmentUse
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initializeViewModel()
+        initializeRecyclerView()
         collectData()
     }
 
@@ -44,11 +46,35 @@ class UserListTabFragment : BaseFragment<FragmentUserListTabBinding>(FragmentUse
                 userAdapter.isOwner = isOwner
             }
         }
+
+        repeatOnStarted {
+            event.collect { event ->
+                handleEvent(event)
+            }
+        }
     }
 
-    private fun initializeViewModel() = with(binding) {
+    private fun handleEvent(event: PartyInformationViewModel.PartyInformationEvent) {
+        when(event) {
+            is PartyInformationViewModel.PartyInformationEvent.UserBanSuccess -> {
+                Toast.makeText(requireContext(), "해당 유저를 내보냈습니다", Toast.LENGTH_SHORT).show()
+            }
+
+            is PartyInformationViewModel.PartyInformationEvent.UserBanFailed -> {
+                Toast.makeText(requireContext(), "잠시 후 다시 시도해 보세요", Toast.LENGTH_SHORT).show()
+            }
+
+            else -> Unit
+        }
+    }
+
+    private fun initializeRecyclerView() = with(binding) {
         rvUser.adapter = userAdapter
         rvUser.setHasFixedSize(true)
         rvUser.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+
+        userAdapter.setBanButtonListener { user ->
+            viewModel.occurEvent(BanUserFromParty(user))
+        }
     }
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/UserListTabFragment.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/fragments/UserListTabFragment.kt
@@ -18,6 +18,7 @@ import yapp.android1.delibuddy.databinding.FragmentUserListTabBinding
 import yapp.android1.delibuddy.ui.partyInformation.PartyInformationViewModel
 import yapp.android1.delibuddy.ui.partyInformation.PartyInformationViewModel.PartyInformationAction.*
 import yapp.android1.delibuddy.util.extensions.repeatOnStarted
+import yapp.android1.delibuddy.util.extensions.showCustomDialog
 
 @AndroidEntryPoint
 class UserListTabFragment : BaseFragment<FragmentUserListTabBinding>(FragmentUserListTabBinding::inflate) {
@@ -74,7 +75,12 @@ class UserListTabFragment : BaseFragment<FragmentUserListTabBinding>(FragmentUse
         rvUser.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
 
         userAdapter.setBanButtonListener { user ->
-            viewModel.occurEvent(BanUserFromParty(user))
+            requireContext().showCustomDialog(
+                title          = "경고",
+                message        = "정말 추방하시겠습니까?",
+                positiveMethod = { viewModel.occurEvent(BanUserFromParty(user)) },
+                negativeMethod = null
+            )
         }
     }
 }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/model/PartyStatus.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/ui/partyInformation/model/PartyStatus.kt
@@ -9,10 +9,10 @@ enum class PartyStatus(val value: String) {
     companion object {
         fun of(value: String): PartyStatus {
             return when(value) {
-                "모집중" -> RECRUIT
-                "주문중" -> ORDER
-                "주문완료" -> COMPLETED
-                else -> throw RuntimeException("올바른 Status가 아닙니다")
+                "모집중"    -> RECRUIT
+                "주문중"    -> ORDER
+                "주문완료"  -> COMPLETED
+                else      -> throw RuntimeException("올바른 Status가 아닙니다")
             }
         }
     }

--- a/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/util/extensions/VIewExtensions.kt
+++ b/DeliBuddy/app/src/main/java/yapp/android1/delibuddy/util/extensions/VIewExtensions.kt
@@ -1,8 +1,12 @@
 package yapp.android1.delibuddy.util.extensions
 
 import android.app.Activity
+import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import yapp.android1.delibuddy.R
 
 
 fun View.show() {
@@ -31,4 +35,18 @@ fun View.showKeyboard(isForced: Boolean = false) {
 fun View.hideKeyboard() {
     val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
+}
+
+fun Context.showToast(body: String, duration: Int = Toast.LENGTH_SHORT) {
+    Toast.makeText(this, body, duration).show()
+}
+
+fun Context.showCustomDialog(title: String, message: String, positiveMethod: () -> Unit, negativeMethod: (() -> Unit)?) {
+    MaterialAlertDialogBuilder(this, R.style.MaterialDialog_DeliBuddy_Style)
+        .setTitle(title)
+        .setIcon(R.drawable.icon_delibuddy_foreground)
+        .setMessage(message)
+        .setPositiveButton("확인") { _, _ -> positiveMethod.invoke() }
+        .setNegativeButton("취소") { _, _ -> negativeMethod?.invoke()}
+        .show()
 }

--- a/DeliBuddy/app/src/main/res/layout/activity_party_information.xml
+++ b/DeliBuddy/app/src/main/res/layout/activity_party_information.xml
@@ -3,6 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:layout_height="match_parent">
 
     <!-- Body -->
@@ -293,94 +296,103 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_target_comment_container"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="44dp"
         android:layout_gravity="bottom"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="56dp"
-        android:background="@drawable/shape_rounded_grey_edittext"
-        android:paddingHorizontal="12dp"
-        android:visibility="invisible">
+        android:layout_height="120dp">
 
-        <ImageView
-            android:id="@+id/iv_icon_reply"
-            android:layout_width="12dp"
-            android:layout_height="12dp"
-            android:src="@drawable/icon_reply"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_parent_comment_writer"
-            style="@style/RobotoRegular10"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:text="김선달 님에게 답장"
-            android:textColor="#686868"
-            app:layout_constraintBottom_toTopOf="@+id/tv_parent_comment_body"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/iv_icon_reply"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_chainStyle="packed" />
-
-        <TextView
-            android:id="@+id/tv_parent_comment_body"
-            style="@style/RobotoRegular10"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="2dp"
-            android:text="저 참여해도 되나요??"
-            android:textColor="#B8B8B8"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/tv_parent_comment_writer"
-            app:layout_constraintTop_toBottomOf="@+id/tv_parent_comment_writer" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <!-- Input Comment -->
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_input_comment_container"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:layout_gravity="bottom"
-        android:background="@color/white"
-        android:elevation="20dp"
-        android:outlineSpotShadowColor="@color/shadow_grey"
-        android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <EditText
-            android:id="@+id/et_input_comment"
-            style="@style/RobotoRegular14"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_target_comment_container"
             android:layout_width="match_parent"
-            android:layout_height="40dp"
+            android:layout_height="44dp"
+            android:layout_gravity="bottom"
             android:layout_marginHorizontal="20dp"
             android:background="@drawable/shape_rounded_grey_edittext"
-            android:paddingStart="12dp"
-            android:paddingEnd="40dp"
+            android:paddingHorizontal="12dp"
+            android:layout_marginBottom="12dp"
+            android:visibility="visible">
+
+            <ImageView
+                android:id="@+id/iv_icon_reply"
+                android:layout_width="12dp"
+                android:layout_height="12dp"
+                android:src="@drawable/icon_reply"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_parent_comment_writer"
+                style="@style/RobotoRegular10"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:text="김선달 님에게 답장"
+                android:textColor="#686868"
+                app:layout_constraintBottom_toTopOf="@+id/tv_parent_comment_body"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/iv_icon_reply"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <TextView
+                android:id="@+id/tv_parent_comment_body"
+                style="@style/RobotoRegular10"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="저 참여해도 되나요??"
+                android:textColor="#B8B8B8"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/tv_parent_comment_writer"
+                app:layout_constraintTop_toBottomOf="@+id/tv_parent_comment_writer" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- Input Comment -->
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_input_comment_container"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="@color/white"
+            android:elevation="20dp"
+            android:layout_gravity="bottom"
+            android:outlineSpotShadowColor="@color/shadow_grey"
+            android:visibility="visible"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="저도 참여하고 싶은데" />
+            app:layout_constraintStart_toStartOf="parent">
 
-        <ImageView
-            android:id="@+id/btn_create_comment"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:src="@drawable/icon_send_comment"
-            app:layout_constraintBottom_toBottomOf="@+id/et_input_comment"
-            app:layout_constraintEnd_toEndOf="@+id/et_input_comment"
-            app:layout_constraintTop_toTopOf="@+id/et_input_comment" />
+            <EditText
+                android:id="@+id/et_input_comment"
+                style="@style/RobotoRegular14"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:layout_marginHorizontal="20dp"
+                android:background="@drawable/shape_rounded_grey_edittext"
+                android:paddingStart="12dp"
+                android:paddingEnd="40dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="저도 참여하고 싶은데" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ImageView
+                android:id="@+id/btn_create_comment"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:src="@drawable/icon_send_comment"
+                app:layout_constraintBottom_toBottomOf="@+id/et_input_comment"
+                app:layout_constraintEnd_toEndOf="@+id/et_input_comment"
+                app:layout_constraintTop_toTopOf="@+id/et_input_comment" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </FrameLayout>
+
+
 
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/DeliBuddy/app/src/main/res/layout/item_user.xml
+++ b/DeliBuddy/app/src/main/res/layout/item_user.xml
@@ -29,7 +29,7 @@
         app:layout_constraintTop_toTopOf="@+id/iv_icon_user" />
 
     <ImageView
-        android:id="@+id/btn_kick_out"
+        android:id="@+id/btn_ban"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="12dp"
@@ -45,7 +45,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
         app:layout_constraintBottom_toBottomOf="@+id/iv_icon_user"
-        app:layout_constraintEnd_toStartOf="@+id/btn_kick_out"
+        app:layout_constraintEnd_toStartOf="@+id/btn_ban"
         app:layout_constraintStart_toEndOf="@+id/iv_icon_user"
         app:layout_constraintTop_toTopOf="@+id/iv_icon_user"
         tools:text="홍길동 (나)" />

--- a/DeliBuddy/app/src/main/res/values/themes.xml
+++ b/DeliBuddy/app/src/main/res/values/themes.xml
@@ -23,4 +23,16 @@
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
     </style>
+
+    <style name="MaterialDialog_DeliBuddy_Style" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+        <item name="materialAlertDialogTitleTextStyle">@style/MaterialAlertDialog.DeliBuddy.Title.Text</item>
+        <item name="materialAlertDialogBodyTextStyle">@style/MaterialAlertDialog.DeliBuddy.Title.Text</item>
+        <item name="materialButtonStyle">@style/MaterialAlertDialog.DeliBuddy.Title.Text</item>
+    </style>
+
+    <style name="MaterialAlertDialog.DeliBuddy.Title.Text" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+        <item name="fontFamily"> @font/roboto_bold</item>
+        <item name="android:textSize">14dp</item>
+    </style>
+
 </resources>

--- a/DeliBuddy/data/src/main/java/yapp/android1/data/entity/PartyBanRequestModel.kt
+++ b/DeliBuddy/data/src/main/java/yapp/android1/data/entity/PartyBanRequestModel.kt
@@ -3,7 +3,7 @@ package yapp.android1.data.entity
 import yapp.android1.domain.entity.PartyBanRequestEntity
 
 data class PartyBanRequestModel(
-    val targetId: String,
+    val targetId: Int,
 ) {
     companion object {
         fun fromPartyBanRequest(entity: PartyBanRequestEntity): PartyBanRequestModel {

--- a/DeliBuddy/data/src/main/java/yapp/android1/data/remote/PartyApi.kt
+++ b/DeliBuddy/data/src/main/java/yapp/android1/data/remote/PartyApi.kt
@@ -33,9 +33,9 @@ interface PartyApi : DeliBuddyApi {
 
     @POST("api/v1/parties/{id}/ban")
     suspend fun banFromParty(
-        @Path("id") id: String,
+        @Path("id") id: Int,
         @Body partyBanRequestModel: PartyBanRequestModel,
-    ): Unit
+    ): PostResponseModel
 
     @POST("api/v1/parties/{id}/join")
     suspend fun joinParty(

--- a/DeliBuddy/data/src/main/java/yapp/android1/data/repository/PartyRepositoryImpl.kt
+++ b/DeliBuddy/data/src/main/java/yapp/android1/data/repository/PartyRepositoryImpl.kt
@@ -74,14 +74,18 @@ class PartyRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun banFromParty(id: String, request: PartyBanRequestEntity): NetworkResult<Unit> {
-        return try {
-            val response = api.banFromParty(id, PartyBanRequestModel.fromPartyBanRequest(request))
-            NetworkResult.Success(response)
-        } catch (e: Exception) {
-            val errorType = deliBuddyNetworkErrorHandler.getError(exception = e)
-            return NetworkResult.Error(errorType)
-        }
+    override suspend fun banFromParty(id: Int, request: PartyBanRequestEntity): NetworkResult<Boolean> {
+        return runCatching {
+            api.banFromParty(id, PartyBanRequestModel.fromPartyBanRequest(request))
+        }.fold(
+            onSuccess = { model ->
+                NetworkResult.Success(model.okay)
+            },
+            onFailure = { throwable ->
+                val errorType = deliBuddyNetworkErrorHandler.getError(exception = throwable)
+                NetworkResult.Error(errorType)
+            }
+        )
     }
 
     override suspend fun joinParty(id: Int): NetworkResult<Boolean> {

--- a/DeliBuddy/domain/src/main/java/yapp/android1/domain/entity/PartyBanRequestEntity.kt
+++ b/DeliBuddy/domain/src/main/java/yapp/android1/domain/entity/PartyBanRequestEntity.kt
@@ -1,5 +1,5 @@
 package yapp.android1.domain.entity
 
 data class PartyBanRequestEntity(
-    val targetId: String,
+    val targetId: Int,
 )

--- a/DeliBuddy/domain/src/main/java/yapp/android1/domain/interactor/usecase/PartyInformationUseCase.kt
+++ b/DeliBuddy/domain/src/main/java/yapp/android1/domain/interactor/usecase/PartyInformationUseCase.kt
@@ -73,3 +73,18 @@ class EditPartyUseCase @Inject constructor(
         val requestEntity: PartyEditRequestEntity
     )
 }
+
+class BanFromPartyUseCase @Inject constructor(
+    private val partyRepository: PartyRepository
+) : BaseUseCase<NetworkResult<Boolean>, BanFromPartyUseCase.Params>() {
+
+    override suspend fun run(params: Params): NetworkResult<Boolean> {
+        return partyRepository.banFromParty(params.partyId, params.requestEntity)
+    }
+
+    data class Params(
+        val partyId: Int,
+        val requestEntity: PartyBanRequestEntity
+    )
+
+}

--- a/DeliBuddy/domain/src/main/java/yapp/android1/domain/repository/PartyRepository.kt
+++ b/DeliBuddy/domain/src/main/java/yapp/android1/domain/repository/PartyRepository.kt
@@ -10,7 +10,7 @@ interface PartyRepository {
     suspend fun getPartyInformation(id: Int): NetworkResult<PartyInformationEntity>
     suspend fun editParty(id: Int, request: PartyEditRequestEntity): NetworkResult<Boolean>
     suspend fun deleteParty(id: Int): NetworkResult<Boolean>
-    suspend fun banFromParty(id: String, request: PartyBanRequestEntity): NetworkResult<Unit>
+    suspend fun banFromParty(id: Int, request: PartyBanRequestEntity): NetworkResult<Boolean>
     suspend fun joinParty(id: Int): NetworkResult<Boolean>
     suspend fun leaveParty(id: String): NetworkResult<Unit>
     suspend fun changeStatus(id: Int, request: StatusChangeRequestEntity): NetworkResult<Boolean>


### PR DESCRIPTION
- [x]  참가중인 버튼을 누르면 해당 카카오톡 링크로 이동하게끔 유도해야 함
- [x]  삭제나 강퇴 누를 시 다이얼로그 한번 띄우기
- [x]  유저 리스트 Ban시키는 api 요청문의( path params하고 json을 둘다 보내야 하는게 맞는지)후 구현
    - PathParam : PartyId
    - Body : UserId
- [x]  화면 진입 시 파티 참가중이면 참가중 표시, Owner일때는 어떻게 할것인지?
- [x]  Comment부분에서 TargetComment에 대한 애니메이션 필요