### PR TITLE
fix(base): 카카오 로그인이 안되는 문제 해결

### DIFF
--- a/DeliBuddy/app/build.gradle.kts
+++ b/DeliBuddy/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
         }
 
         getByName(Configs.RELEASE) {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             isDebuggable = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 
@@ -60,7 +60,7 @@ android {
         }
 
         create(Configs.QA) {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             isDebuggable = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 

--- a/DeliBuddy/app/proguard-rules.pro
+++ b/DeliBuddy/app/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+-keep class * extends com.google.gson.TypeAdapter

--- a/DeliBuddy/buildSrc/src/main/java/Configs.kt
+++ b/DeliBuddy/buildSrc/src/main/java/Configs.kt
@@ -10,8 +10,8 @@ object Configs {
     const val APPLICATION_ID            = "yapp.android1.delibuddy"
     const val MIN_SDK                   = 24
     const val TARGET_SDK                = 30
-    const val VERSION_CODE              = 3
-    const val VERSION_NAME              = "1.0.1"
+    const val VERSION_CODE              = 4
+    const val VERSION_NAME              = "1.0.2"
 
     //BuildType
     const val RELEASE                   = "release"

--- a/DeliBuddy/buildSrc/src/main/java/Configs.kt
+++ b/DeliBuddy/buildSrc/src/main/java/Configs.kt
@@ -10,8 +10,8 @@ object Configs {
     const val APPLICATION_ID            = "yapp.android1.delibuddy"
     const val MIN_SDK                   = 24
     const val TARGET_SDK                = 30
-    const val VERSION_CODE              = 1
-    const val VERSION_NAME              = "1.0.0"
+    const val VERSION_CODE              = 3
+    const val VERSION_NAME              = "1.0.1"
 
     //BuildType
     const val RELEASE                   = "release"


### PR DESCRIPTION
- minify로 코드가 난독화가 되어서 Auth 객체를 가져오지 못하는 문제 발견 ->  isMinify = false로 변경
- 버전코드 4로 증가 , 버전 1.0.2